### PR TITLE
feat: implement search by title in prize explore pages (#71)

### DIFF
--- a/apps/client/app/(dashboard)/prize/explore/fetchprizes.tsx
+++ b/apps/client/app/(dashboard)/prize/explore/fetchprizes.tsx
@@ -3,28 +3,47 @@ import ExploreCard from '@/components/Prize/ExplorePrize/explorePrize';
 import { FetchPrizesCsv } from '@/components/history/fetch-csv';
 import HistoryCard from '@/components/history/history-card';
 import { Api } from '@/lib/api';
+import { Text } from '@mantine/core';
 
-export default async function FetchPrizes() {
-  const prizes = (
-    await new Api().prizes.prizesList(
+export default async function FetchPrizes({ searchParams }: { searchParams?: { search?: string } }) {
+  // Get search query from URL params if available
+  const searchQuery = searchParams?.search;
+
+  let prizes: any[] = [];
+  let error: string | null = null;
+
+  try {
+    const response = await new Api().prizes.prizesList(
       {
         limit: 20,
         page: 1,
+        ...(searchQuery ? { search: searchQuery } : {}),
       },
       {
         next: {
           revalidate: 0,
         },
       },
-    )
-  ).data.data;
-
-  console.log(prizes[0], 'prizes');
+    );
+    prizes = response.data.data;
+  } catch (e) {
+    error = 'Failed to load prizes. Please try again later.';
+  }
 
   const data = await FetchPrizesCsv();
 
   return (
     <>
+      {error && (
+        <Text c="red" size="md" ta="center" mt="md">
+          {error}
+        </Text>
+      )}
+      {!error && prizes.length === 0 && (
+        <Text size="md" ta="center" mt="md" c="dimmed">
+          {searchQuery ? 'No prizes found matching your search.' : 'No prizes available.'}
+        </Text>
+      )}
       {prizes.map((prize) => {
         return (
           <ExploreCard
@@ -54,22 +73,20 @@ export default async function FetchPrizes() {
       })}
 
       {data.reverse().map((prize) => {
-        // Reverse the data array
         if (
           (prize.Awarded &&
-            // prize.WonRefunded &&
             prize.PrizeName) ||
           prize.DatePosted ||
           prize.AwardedUSDe ||
-          prize.WinnersAmount // Changed this line
+          prize.WinnersAmount
         ) {
-          const status = prize.WinnersAmount ? 'Won' : 'Refunded'; // Adjusted status based on WinnersAmount existence
+          const status = prize.WinnersAmount ? 'Won' : 'Refunded';
           return (
             <HistoryCard
               key={prize.Id}
               imageUrl={prize.CardImage}
               id={prize.Id}
-              status={status} // Passed the adjusted status here
+              status={status}
               datePosted={prize.DatePosted}
               title={prize.PrizeName}
               description={prize.SimpleDescription}

--- a/apps/client/app/(dashboard)/prize/explore/page.tsx
+++ b/apps/client/app/(dashboard)/prize/explore/page.tsx
@@ -1,11 +1,12 @@
 import SkeletonLoad from '@/components/custom/skeleton-load-explore';
+import SearchFilters from '@/components/Prize/ExplorePrize/searchFilters';
 import { Button, Group, Text } from '@mantine/core';
 import Link from 'next/link';
 import { Suspense } from 'react';
 import FetchPrizes from './fetchprizes';
 import SubscriptionForm from '@/components/newsletter/subscriptionForm';
 
-function ExplorePage() {
+function ExplorePage({ searchParams }: { searchParams?: { search?: string } }) {
   return (
     <div className="max-w-screen-xl">
       <div className="sm:flex justify-between">
@@ -31,16 +32,15 @@ function ExplorePage() {
         </div>
       </div>
 
-      {/* <SearchFilters /> */}
+      {/* Search filters with title-based search */}
+      <SearchFilters />
+
       <div className="p-3 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3  gap-4">
         <Suspense fallback={<SkeletonLoad />}>
           {/* @ts-expect-error Server Component */}
-          <FetchPrizes />
+          <FetchPrizes searchParams={searchParams} />
         </Suspense>
-        {/* Add as many ExploreCard components as you need */}
       </div>
-
-      {/* <HistoryPage /> */}
     </div>
   );
 }

--- a/apps/client/components/Prize/ExplorePrize/searchFilters.tsx
+++ b/apps/client/components/Prize/ExplorePrize/searchFilters.tsx
@@ -4,12 +4,11 @@
 'use client';
 
 import { Button, Drawer, Group, Menu, TextInput } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
-import { IconSearch } from '@tabler/icons-react';
+import { useDisclosure, useDebouncedCallback } from '@mantine/hooks';
+import { IconSearch, IconX } from '@tabler/icons-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Filter from './filterComponent';
 import Link from 'next/link';
-// import Filter from "./filterComponent";
 
 type Sorts = Record<string, string>;
 
@@ -34,6 +33,21 @@ export default function SearchFilters() {
   const searchParams = useSearchParams();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- its needed
   const params = new URLSearchParams(searchParams as any as string);
+  const currentSearch = searchParams?.get('search') || '';
+
+  const handleSearch = useDebouncedCallback((value: string) => {
+    if (value.length >= 3) {
+      params.set('search', value);
+    } else {
+      params.delete('search');
+    }
+    router.replace({ query: params.toString() });
+  }, 500);
+
+  const handleClear = () => {
+    params.delete('search');
+    router.replace({ query: params.toString() });
+  };
 
   const handleSort = (value: string) => {
     params.set('sort', value);
@@ -44,9 +58,17 @@ export default function SearchFilters() {
     <div className="p-5">
       <Group mb="xs" mt="md" justify="space-between">
         <TextInput
-          rightSection={<IconSearch size="1rem" />}
-          placeholder="Search"
+          rightSection={
+            currentSearch ? (
+              <IconX size="1rem" onClick={handleClear} style={{ cursor: 'pointer' }} />
+            ) : (
+              <IconSearch size="1rem" />
+            )
+          }
+          placeholder="Search by title..."
           className="sm:w-[500px]"
+          defaultValue={currentSearch}
+          onChange={(e) => handleSearch(e.currentTarget.value)}
         />
         <Group justify="space-between">
           <Link href="/prize/about">
@@ -55,35 +77,6 @@ export default function SearchFilters() {
           <Link href="/prize/create">
             <Button>Create Prize </Button>
           </Link>
-
-          {/* <Button onClick={open}>Filter</Button> */}
-          {/* <Menu shadow="md" width={200}>
-            <Menu.Target>
-              <Button>Sort</Button>
-            </Menu.Target>
-
-            <Menu.Dropdown>
-              <Menu.Label>Sort By</Menu.Label>
-              <Menu.Divider />
-              {sortKeys.map((key) => {
-                return (
-                  <Menu.Item
-                    key={key.value}
-                    onClick={() => {
-                      handleSort(key.value);
-                    }}
-                    className={`${
-                      key.value === searchParams?.get('sort')
-                        ? 'font-bold'
-                        : 'font-normal'
-                    }`}
-                  >
-                    {key.label}
-                  </Menu.Item>
-                );
-              })}
-            </Menu.Dropdown>
-          </Menu> */}
         </Group>
       </Group>
       <Drawer opened={opened} onClose={close} title="Filters" position="right">


### PR DESCRIPTION
## Implement Search Feature By Title in Prizes Explore Pages (#71)

Addresses issue #71 ($50 bounty)

### Changes
- **searchFilters.tsx**: Wired up TextInput with `onChange` handler, debounced search (500ms via `@mantine/hooks` `useDebouncedCallback`), URL param state, clear button integrated in input `rightSection`
- **page.tsx**: Added `searchParams` prop, passes to `<FetchPrizes searchParams={searchParams} />`, uncommented `<SearchFilters />`
- **fetchprizes.tsx**: Added `searchParams` prop, reads `search` query param and passes to API. Added error/empty states. Preserved exact upstream HistoryCard mapping.

### How it works
1. User types in search bar -> 500ms debounce via `useDebouncedCallback`
2. If >=3 characters: updates `?search=` URL param -> triggers re-fetch
3. Clear button appears in input `rightSection` when text exists
4. Backend title search is already supported (issue #58 is closed)

### Preserved from upstream
- HistoryCard field mapping (CardImage->imageUrl, PrizeName->title, etc.) with filter
- ExploreCard props (including `startVotingDate` and `contributers`)
- All existing routes, proxy headers, and component structure
